### PR TITLE
Switch to DateTime::Format::ICal from Date::ICal to appease Debian

### DIFF
--- a/META.yml
+++ b/META.yml
@@ -23,7 +23,7 @@ no_index:
     - RT::Interface::Web::Menu
 requires:
   Data::ICal: 0
-  Date::ICal: 0
+  DateTime::Format::ICal: 0
   DateTime: 0
   DateTime::Set: 0
   Digest::SHA: 0

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -9,7 +9,7 @@ readme_from('lib/RTx/Calendar.pm');
 requires 'DateTime'      => 0;
 requires 'DateTime::Set' => 0;
 requires 'Data::ICal'    => 0;
-requires 'Date::ICal'    => 0;
+requires 'DateTime::Format::ICal'    => 0;
 requires 'Digest::SHA';
 
 no_index(package => 'RT::Interface::Web::Menu');

--- a/README
+++ b/README
@@ -17,7 +17,7 @@ INSTALLATION
 
     You need to install those three modules :
 
-      * Date::ICal
+      * DateTime::Format::ICal
       * Data::ICal
       * DateTime::Set
 

--- a/html/NoAuth/Calendar/dhandler
+++ b/html/NoAuth/Calendar/dhandler
@@ -3,7 +3,8 @@
 use Data::ICal;
 use Data::ICal::Entry::Todo;
 use Data::ICal::Entry::Event;
-use Date::ICal;
+use DateTime;
+use DateTime::Format::ICal;
 
 $RT::ICalTicketType   ||= "Data::ICal::Entry::Todo";
 $RT::ICalReminderType ||= "Data::ICal::Entry::Event";
@@ -112,9 +113,9 @@ sub add_event {
     my %event = (
 	summary => $Reminder->Subject ? $Reminder->Subject : '',
 	url        => "${RT::WebURL}/Ticket/Display.html?id=" . $Ticket->id,
-	uid        => Date::ICal->new( epoch => time() )->ical() . "-" . $Reminder->Id . "@" . $uid,
+	uid        => DateTime::Format::ICal->format_datetime( DateTime->from_epoch( epoch => time() ) ) . "-" . $Reminder->Id . "@" . $uid,
 	categories => $Ticket->QueueObj->Name,
-	dtstart     => Date::ICal->new( epoch => $Reminder->DueObj->Unix )->ical,
+	dtstart     => DateTime::Format::ICal->format_datetime( DateTime->from_epoch( epoch => $Reminder->DueObj->Unix ) ),
     );
 
     my $event = $RT::ICalReminderType->new();
@@ -128,13 +129,13 @@ sub add_todo {
 
     my %vtodo = (
 	summary    => $Ticket->Subject ? $Ticket->Subject : '',
-	dtstart    => Date::ICal->new( epoch => $Ticket->CreatedObj->Unix )->ical,
+	dtstart    => DateTime::Format::ICal->format_datetime( DateTime->from_epoch( epoch => $Ticket->CreatedObj->Unix ) ),
 	url        => "${RT::WebURL}/Ticket/Display.html?id=" . $Ticket->id,
-	uid        => Date::ICal->new( epoch => time() )->ical() . "-" . $Ticket->Id . "@" . $uid,
+	uid        => DateTime::Format::ICal->format_datetime( DateTime->from_epoch( epoch => time() ) ) . "-" . $Ticket->Id . "@" . $uid,
 	categories => $Ticket->QueueObj->Name,
     );
 
-    $vtodo{due} = Date::ICal->new( epoch => $Ticket->DueObj->Unix )->ical,
+    $vtodo{due} = DateTime::Format::ICal->format_datetime( DateTime->from_epoch( epoch => $Ticket->DueObj->Unix ) ),
         if $Ticket->DueObj;
 
     if ($Ticket->OwnerObj->Id != $RT::Nobody->Id and $Ticket->OwnerObj->EmailAddress) {

--- a/lib/RTx/Calendar.pm
+++ b/lib/RTx/Calendar.pm
@@ -153,7 +153,7 @@ If you upgrade from 0.02, see next part before.
 
 You need to install those three modules :
 
-  * Date::ICal
+  * DateTime::Format::ICal
   * Data::ICal
   * DateTime::Set
 


### PR DESCRIPTION
hi,

This PR would simply replace deprecated Date::ICal module.

cf.
http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=653301
http://cpansearch.perl.org/src/RBOW/Date-ICal-2.678/Changes
